### PR TITLE
Update publish.php

### DIFF
--- a/admin/publish.php
+++ b/admin/publish.php
@@ -184,6 +184,7 @@ function xyz_fbap_link_publish($post_ID) {
 
 		$name=strip_tags($name);
 		$name=strip_shortcodes($name);
+		$name=str_replace("&amp;","&",$name);
 		
 		$description=strip_tags($description);		
 		$description=strip_shortcodes($description);


### PR DESCRIPTION
Many word press import plugins still use the &amp; for &

This small code is similar to what you are doing with

$description=str_replace("&nbsp;","",$description);
